### PR TITLE
[Feature/#99] : 저장 홈이랑 공지 세부사항 연결

### DIFF
--- a/app/src/main/java/com/univoice/feature/noticeDetail/NoticeDetailFragment.kt
+++ b/app/src/main/java/com/univoice/feature/noticeDetail/NoticeDetailFragment.kt
@@ -14,6 +14,7 @@ import com.univoice.core_ui.view.UiState
 import com.univoice.databinding.FragmentNoticeDetailBinding
 import com.univoice.domain.entity.NoticeDetailEntity
 import com.univoice.feature.home.HomeFragment
+import com.univoice.feature.storage.StorageFragment
 import com.univoice.feature.util.CalculateDate
 import com.univoice.feature.util.Debouncer
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,7 +33,14 @@ class NoticeDetailFragment :
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
         val view = super.onCreateView(inflater, container, savedInstanceState)
-        noticeId = arguments?.getInt(HomeFragment.DETAIL_KEY)
+        val previousBackStackEntry = findNavController().previousBackStackEntry
+        previousBackStackEntry?.destination?.id?.let { previousDestinationId ->
+            when (previousDestinationId) {
+                R.id.fragment_home -> noticeId = arguments?.getInt(HomeFragment.DETAIL_KEY)
+                R.id.fragment_storage -> noticeId = arguments?.getInt(StorageFragment.STORAGE_KEY)
+                else -> Timber.d("Unknown previous fragment")
+            }
+        }
         return view
     }
 

--- a/app/src/main/java/com/univoice/feature/storage/StorageAdapter.kt
+++ b/app/src/main/java/com/univoice/feature/storage/StorageAdapter.kt
@@ -8,7 +8,7 @@ import com.univoice.databinding.ItemNoticeBinding
 import com.univoice.domain.entity.NoticeListEntity
 
 class StorageAdapter(
-    private val onClick: (NoticeListEntity, Int) -> Unit = { _, _ -> },
+    private val onClick: (NoticeListEntity) -> Unit = { _ -> },
 ) : ListAdapter<NoticeListEntity, StorageViewHolder>(
     StorageAdapterDiffCallback
 ) {

--- a/app/src/main/java/com/univoice/feature/storage/StorageFragment.kt
+++ b/app/src/main/java/com/univoice/feature/storage/StorageFragment.kt
@@ -1,5 +1,7 @@
 package com.univoice.feature.storage
 
+import android.os.Bundle
+import androidx.compose.runtime.Composable
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -32,14 +34,21 @@ class StorageFragment : BindingFragment<FragmentStorageBinding>(R.layout.fragmen
     }
 
     private fun initStorageAdapter(data: List<NoticeListEntity>) {
-        binding.rvStorageList.adapter = StorageAdapter(onClick = { data, position ->
-            navigateToNoticeDetail(data, position)
+        binding.rvStorageList.adapter = StorageAdapter(onClick = { data ->
+            navigateToNoticeDetail(data.id)
         }).apply {
             submitList(data)
         }
     }
 
-    private fun navigateToNoticeDetail(data: NoticeListEntity, position: Int) {
-        findNavController().navigate(R.id.action_fragment_storage_to_fragment_notice_detail)
+    private fun navigateToNoticeDetail(id: Int) {
+        val bundle = Bundle().apply {
+            putInt(STORAGE_KEY, id)
+        }
+        findNavController().navigate(R.id.action_fragment_storage_to_fragment_notice_detail, bundle)
+    }
+
+    companion object {
+        const val STORAGE_KEY = "storage_detail_key"
     }
 }

--- a/app/src/main/java/com/univoice/feature/storage/StorageViewHolder.kt
+++ b/app/src/main/java/com/univoice/feature/storage/StorageViewHolder.kt
@@ -9,7 +9,7 @@ import com.univoice.feature.util.CalculateDate
 
 class StorageViewHolder(
     private val binding: ItemNoticeBinding,
-    private val onClick: (NoticeListEntity, Int) -> Unit = { _, _ -> },
+    private val onClick: (NoticeListEntity) -> Unit = { _ -> },
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(data: NoticeListEntity) {
         with(binding) {
@@ -22,7 +22,7 @@ class StorageViewHolder(
                 transformations(RoundedCornersTransformation(5f))
             }
             root.setOnClickListener {
-                onClick(data, layoutPosition)
+                onClick(data)
             }
         }
     }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요.
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #99

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 저장 홈과 공지 세부사항 화면 연결 했습니다

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/fac9fa72-51a2-4cb0-9e6b-68c4def5fa53

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
navigation 백스택으로 id 값 다르게 가져오는 로직으로 짰는데 괜찮을까요?